### PR TITLE
Double fetch prevent

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -8,7 +8,9 @@ module.exports = class User {
         this.id = id;
     };
   
-    async fetchProfile() {
+    async fetchProfile(force = false) {
+        if (this.fetched && !false) return this;
+
         const route = 'profile.tjf?uid=' + this.id;
       
         const html = await Utils.request(route);
@@ -17,6 +19,7 @@ module.exports = class User {
         for(const key in profile)
             this[key] = profile[key];
       
+        this.fetched = true;
         return this;
     };
   

--- a/models/User.js
+++ b/models/User.js
@@ -6,6 +6,7 @@ module.exports = class User {
     constructor(id, name = '') {
         this.name = name;
         this.id = id;
+        this.fetched = false;
     };
   
     async fetchProfile(force = false) {


### PR DESCRIPTION
This prevents someone to fetch again something already fetched
Example:
```js
HappyWheels.getLevel('10037145').then(({ author }) => {    
	console.log(author.fetched) // false
    const fetched = await author.fetchProfile() // This will return a recent fetch
	console.log(author.fetched) // true
	const user = fetched.fetch() // this will return itself, and wont fetch a new one
	const updatedUser = fetched.fetch(true) // this will make the fetch again
});
```

Honestly I don't see why to do this but why not tho